### PR TITLE
Use NuGet package for Newtonsoft.Json

### DIFF
--- a/RandomizerCore/RandomizerCore.csproj
+++ b/RandomizerCore/RandomizerCore.csproj
@@ -8,22 +8,19 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImplicitUsings>true</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Using Remove="System.Net.Http" />
     <Using Remove="System.Threading" />
     <Using Remove="System.Threading.Tasks" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <Using Include="RandomizerCore.LogHelper" Static="true" />
   </ItemGroup>
   <PropertyGroup>
     <WarningsAsErrors>;NU1605</WarningsAsErrors>
     <NoWarn>1701;1702;CS1591</NoWarn>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb;$(TargetDir)$(TargetName).xml" DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\$(TargetName)" SkipUnchangedFiles="true" />
   </Target>


### PR DESCRIPTION
I don't actually have a copy of Hollow Knight, so I'm not sure if the referenced Newtonsoft.Json.dll comes from the HK install or if you just threw it in there.

It seems appropriate to me to use the NuGet package instead, as Visual Studio can resolve those automatically when building the solution. This makes it easier for a collaborator to pick up and develop, and it doesn't rely on keeping your installs at the same paths. 

This might not be the exact version that was used previously. Feel free to change the version or let me know. I did make sure that it at least compiles. 😄 