### PR TITLE
Add profiling code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,4 @@ MigrationBackup/
 FodyWeavers.xsd
 
 /docs
+/RandomizerCore/LocalOverrides.targets

--- a/RandomizerCore/Logic/LogicManager.cs
+++ b/RandomizerCore/Logic/LogicManager.cs
@@ -345,7 +345,9 @@ namespace RandomizerCore.Logic
                 Expand(tokens);
                 _DNFConverter.Convert(tokens);
                 List<List<TermToken>> res = _DNFConverter.Result;
-                return new(CreateClauses, this, name, Infix.ToInfix(tokens));
+                DNFLogicDef result = new(CreateClauses, this, name, Infix.ToInfix(tokens));
+                Profiling.EmitMetric("LogicManager.CreateDNFLogicDef.ResultingTermCount", result.GetTerms().Count());
+                return result;
 
                 DNFLogicDef.Clause[] CreateClauses(DNFLogicDef parent)
                 {

--- a/RandomizerCore/Profiling.cs
+++ b/RandomizerCore/Profiling.cs
@@ -8,13 +8,22 @@ namespace RandomizerCore
         private static readonly Dictionary<string, List<double>> committedMetrics = new();
         private static readonly Dictionary<string, List<double>> metrics = new();
 
+        /// <summary>
+        /// Fully resets all committed, uncommitted, and reverted datapoints.
+        /// </summary>
         [Conditional("DEBUG")]
         public static void Reset()
         {
             metrics.Clear();
+            revertedMetrics.Clear();
             committedMetrics.Clear();
         }
 
+        /// <summary>
+        /// Emits a datapoint for the specified metric
+        /// </summary>
+        /// <param name="name">The metric name. Should be unique to the code being profiled.</param>
+        /// <param name="value">The value to emit.</param>
         [Conditional("DEBUG")]
         internal static void EmitMetric(string name, double value)
         {
@@ -25,6 +34,9 @@ namespace RandomizerCore
             metrics[name].Add(value);
         }
 
+        /// <summary>
+        /// Commits all staged emitted metrics.
+        /// </summary>
         [Conditional("DEBUG")]
         public static void Commit()
         {
@@ -42,6 +54,9 @@ namespace RandomizerCore
             metrics.Clear();
         }
 
+        /// <summary>
+        /// Reverts all staged emitted metrics.
+        /// </summary>
         [Conditional("DEBUG")]
         public static void Revert()
         {
@@ -59,6 +74,10 @@ namespace RandomizerCore
             metrics.Clear();
         }
 
+        /// <summary>
+        /// Aggregates and logs metrics in a tabular format. Staged (uncommitted) metrics are not included.
+        /// </summary>
+        /// <param name="includeReverted">Whether to include reverted metrics in the aggregation.</param>
         [Conditional("DEBUG")]
         public static void Log(bool includeReverted = false)
         {

--- a/RandomizerCore/Profiling.cs
+++ b/RandomizerCore/Profiling.cs
@@ -1,0 +1,98 @@
+﻿using System.Diagnostics;
+
+namespace RandomizerCore
+{
+    public static class Profiling
+    {
+        private static readonly Dictionary<string, List<double>> revertedMetrics = new();
+        private static readonly Dictionary<string, List<double>> committedMetrics = new();
+        private static readonly Dictionary<string, List<double>> metrics = new();
+
+        [Conditional("DEBUG")]
+        public static void Reset()
+        {
+            metrics.Clear();
+            committedMetrics.Clear();
+        }
+
+        [Conditional("DEBUG")]
+        internal static void EmitMetric(string name, double value)
+        {
+            if (!metrics.ContainsKey(name))
+            {
+                metrics[name] = new();
+            }
+            metrics[name].Add(value);
+        }
+
+        [Conditional("DEBUG")]
+        public static void Commit()
+        {
+            foreach (var metric in metrics)
+            {
+                if (committedMetrics.ContainsKey(metric.Key))
+                {
+                    committedMetrics[metric.Key].AddRange(metric.Value);
+                }
+                else
+                {
+                    committedMetrics[metric.Key] = metric.Value;
+                }
+            }
+            metrics.Clear();
+        }
+
+        [Conditional("DEBUG")]
+        public static void Revert()
+        {
+            foreach (var metric in metrics)
+            {
+                if (revertedMetrics.ContainsKey(metric.Key))
+                {
+                    revertedMetrics[metric.Key].AddRange(metric.Value);
+                }
+                else
+                {
+                    revertedMetrics[metric.Key] = metric.Value;
+                }
+            }
+            metrics.Clear();
+        }
+
+        [Conditional("DEBUG")]
+        public static void Log(bool includeReverted = false)
+        {
+            const string rowSeparator = "+----------------------------------------------------+----------------+----------------+-----------+";
+            LogDebug(rowSeparator);
+            LogDebug("| Name                                               |           Mean |        Std Dev |         N |");
+            LogDebug(rowSeparator);
+
+            IEnumerable<string> metricsToLog = committedMetrics.Keys;
+            if (includeReverted)
+            {
+                metricsToLog = metricsToLog.Concat(revertedMetrics.Keys);
+            }
+
+            foreach (string name in metricsToLog.Distinct())
+            {
+                List<double> values = new();
+                if (committedMetrics.TryGetValue(name, out List<double> committedValues))
+                {
+                    values.AddRange(committedValues);
+                }
+                if (includeReverted && revertedMetrics.TryGetValue(name, out List<double> revertedValues))
+                {
+                    values.AddRange(revertedValues);
+                }
+                double sum = values.Sum();
+                double n = values.Count;
+                double mean = sum / n;
+                // use sample standard deviation - we're sampling out of an approximately infinitely large population
+                double squaredSampleVariance = values.Select(x => (x - mean) * (x - mean)).Sum() / (n - 1);
+                double sampleStdDev = Math.Sqrt(squaredSampleVariance);
+                LogDebug($"| {name,-50} | {mean,14:g7} | {sampleStdDev,14:g7} | {n,9} |");
+                LogDebug(rowSeparator);
+            }
+        }
+    }
+}

--- a/RandomizerCore/RandomizerCore.csproj
+++ b/RandomizerCore/RandomizerCore.csproj
@@ -10,7 +10,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImplicitUsings>true</ImplicitUsings>
     <Nullable>annotations</Nullable>
+    <References>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</References>
   </PropertyGroup>
+
+  <Import Project="LocalOverrides.targets" Condition="Exists('LocalOverrides.targets')"/>
+    
   <ItemGroup>
     <Using Remove="System.Net.Http" />
     <Using Remove="System.Threading" />
@@ -21,7 +25,7 @@
     </PackageReference>
     <Using Include="RandomizerCore.LogHelper" Static="true" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(References)\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <PropertyGroup>
@@ -29,6 +33,6 @@
     <NoWarn>1701;1702;CS1591</NoWarn>
   </PropertyGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb;$(TargetDir)$(TargetName).xml" DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\$(TargetName)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb;$(TargetDir)$(TargetName).xml" DestinationFolder="$(References)\Mods\$(TargetName)" SkipUnchangedFiles="true" />
   </Target>
  </Project>

--- a/RandomizerCore/Updater/MainUpdater.cs
+++ b/RandomizerCore/Updater/MainUpdater.cs
@@ -1,5 +1,6 @@
 ﻿using RandomizerCore.Logic.StateLogic;
 using RandomizerCore.Updater;
+using System.Diagnostics;
 
 namespace RandomizerCore.Logic
 {
@@ -237,7 +238,10 @@ namespace RandomizerCore.Logic
 
         public void DoUpdates()
         {
+            Stopwatch sw = Stopwatch.StartNew();
             while (updates.TryDequeue(out int term)) DoUpdate(term);
+            sw.Stop();
+            Profiling.EmitMetric("MainUpdater.DoUpdate.RuntimeUs", sw.Elapsed.TotalMilliseconds * 1000);
         }
 
         public void DoUpdate(int term)


### PR DESCRIPTION
Adds a static singleton transactional profiler. Callers manage the lifecycle of profiling (corresponding PR to RM will follow shortly)