### PR TITLE
Make the project multitargeted

### DIFF
--- a/RandomizerCore.sln
+++ b/RandomizerCore.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31613.86
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RandomizerCore", "RandomizerCore\RandomizerCore.csproj", "{AE78B8E8-A733-44A2-BE63-D264C82118B7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RandomizerCore", "RandomizerCore\RandomizerCore.csproj", "{AE78B8E8-A733-44A2-BE63-D264C82118B7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/RandomizerCore/Randomization/CombinedItemSelector.cs
+++ b/RandomizerCore/Randomization/CombinedItemSelector.cs
@@ -11,7 +11,7 @@ namespace RandomizerCore.Randomization
     {
         readonly GroupItemSelector[] selectors;
 
-        readonly PriorityQueue<float, GroupItemSelector> openSelectors;
+        readonly RandomizerCore.Collections.PriorityQueue<float, GroupItemSelector> openSelectors;
         readonly Stack<GroupItemSelector> proposeOrder;
         readonly Stack<GroupItemSelector> acceptOrder;
 

--- a/RandomizerCore/RandomizerCore.csproj
+++ b/RandomizerCore/RandomizerCore.csproj
@@ -1,38 +1,51 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <ProjectGuid>ae78b8e8-a733-44a2-be63-d264c82118b7</ProjectGuid>
-    <AssemblyTitle>RandomizerCore</AssemblyTitle>
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
-    <FileVersion>1.1.2.0</FileVersion>
-    <TargetFramework>net472</TargetFramework>
-    <Deterministic>true</Deterministic>
-    <LangVersion>latest</LangVersion>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <ImplicitUsings>true</ImplicitUsings>
-    <Nullable>annotations</Nullable>
-    <References>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</References>
-  </PropertyGroup>
+    <PropertyGroup>
+        <ProjectGuid>ae78b8e8-a733-44a2-be63-d264c82118b7</ProjectGuid>
+        <AssemblyTitle>RandomizerCore</AssemblyTitle>
+        <AssemblyVersion>1.1.2.0</AssemblyVersion>
+        <FileVersion>1.1.2.0</FileVersion>
+        <TargetFrameworks>netstandard2.1;net472;net6.0</TargetFrameworks>
+        <Deterministic>true</Deterministic>
+        <LangVersion>latest</LangVersion>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <ImplicitUsings>true</ImplicitUsings>
+        <Nullable>annotations</Nullable>
+        <References>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</References>
+    </PropertyGroup>
 
-  <Import Project="LocalOverrides.targets" Condition="Exists('LocalOverrides.targets')"/>
+    <Import Project="LocalOverrides.targets" Condition="Exists('LocalOverrides.targets')"/>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+        <PackageReference Include="PolySharp" Version="1.13.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <Reference Include="Newtonsoft.Json">
+            <HintPath>$(References)\Newtonsoft.Json.dll</HintPath>
+        </Reference>
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+        <PackageReference Include="PolySharp" Version="1.13.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Remove="System.Net.Http" />
+        <Using Remove="System.Threading" />
+        <Using Remove="System.Threading.Tasks" />
+        <Using Include="RandomizerCore.LogHelper" Static="true" />
+    </ItemGroup>
+    <PropertyGroup>
+        <WarningsAsErrors>;NU1605</WarningsAsErrors>
+        <NoWarn>1701;1702;CS1591</NoWarn>
+    </PropertyGroup>
     
-  <ItemGroup>
-    <Using Remove="System.Net.Http" />
-    <Using Remove="System.Threading" />
-    <Using Remove="System.Threading.Tasks" />
-    <PackageReference Include="PolySharp" Version="1.8.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <Using Include="RandomizerCore.LogHelper" Static="true" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>$(References)\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <PropertyGroup>
-    <WarningsAsErrors>;NU1605</WarningsAsErrors>
-    <NoWarn>1701;1702;CS1591</NoWarn>
-  </PropertyGroup>
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb;$(TargetDir)$(TargetName).xml" DestinationFolder="$(References)\Mods\$(TargetName)" SkipUnchangedFiles="true" />
-  </Target>
- </Project>
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(TargetFramework)' == 'net472'">
+        <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb;$(TargetDir)$(TargetName).xml" DestinationFolder="$(References)\Mods\$(TargetName)" SkipUnchangedFiles="true" />
+    </Target>
+</Project>

--- a/RandomizerCore/RandomizerCore.csproj
+++ b/RandomizerCore/RandomizerCore.csproj
@@ -16,15 +16,11 @@
     <Import Project="LocalOverrides.targets" Condition="Exists('LocalOverrides.targets')"/>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-        <PackageReference Include="PolySharp" Version="1.13.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <Reference Include="Newtonsoft.Json">
             <HintPath>$(References)\Newtonsoft.Json.dll</HintPath>
         </Reference>
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
         <PackageReference Include="PolySharp" Version="1.13.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
It builds /shrug

I actually did my due diligence here and verified that the only actual change in the .net6 branch for the equivalent commit in the .net472 branch aside from references was that PriorityQueue had to be qualified. So I went and qualified it everywhere because it doesn't hurt anything. You can verify this here: https://github.com/homothetyhk/RandomizerCore/compare/a760c6bea6ed6e8481d2cc8c3eeff759eeb847b6..net-core

If you ever did need TFM-specific code changes you'd be able to do that with [preprocessor checks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#preprocessor-symbols) e.g.

```cs
#if NET472
    // .net 472 specific things
#elif NET6_0
   // .net 6 specific things
#endif 
```