### PR TITLE
Add support for external libraries to define alternate parsing/file format support into LMB deserialization

### DIFF
--- a/RandomizerCore/Logic/ILogicFormat.cs
+++ b/RandomizerCore/Logic/ILogicFormat.cs
@@ -1,0 +1,66 @@
+﻿using RandomizerCore.Logic.StateLogic;
+using RandomizerCore.LogicItems;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RandomizerCore.Logic
+{
+    /// <summary>
+    /// Interface describing a strategy for loading a specific file format into a <see cref="LogicManagerBuilder"/>.
+    /// </summary>
+    /// <seealso cref="LogicManagerBuilder.DeserializeFile(LogicManagerBuilder.JsonType, ILogicFormat, Stream)"/>
+    public interface ILogicFormat
+    {
+        /// <summary>
+        /// Loads a collection of terms from a file.
+        IEnumerable<(string, TermType)> LoadTerms(Stream s);
+        /// <summary>
+        /// Loads a collection of waypoints from a file.
+        /// </summary>
+        IEnumerable<RawWaypointDef> LoadWaypoints(Stream s);
+        /// <summary>
+        /// Loads a collection of transitions from a file.
+        /// </summary>
+        IEnumerable<RawLogicDef> LoadTransitions(Stream s);
+        /// <summary>
+        /// Loads a collection of macros from a file.
+        /// </summary>
+        Dictionary<string, string> LoadMacros(Stream s);
+        /// <summary>
+        /// Loads a collection of items from a file.
+        /// </summary>
+        /// <returns>
+        ///     An IEnumerable which may contain any mix of <see cref="LogicItem"/>s and <see cref="ILogicItemTemplate"/>s.
+        ///     It is the responsibility of format implementations to either forbid the use of items which cannot be constructed
+        ///     without a <see cref="LogicManager"/>, or implicitly construct them as <see cref="ILogicItemTemplate"/>s.
+        /// </returns>
+        IEnumerable<object> LoadItems(Stream s);
+        /// <summary>
+        /// Loads a collection of locations from a file.
+        /// </summary>
+        IEnumerable<RawLogicDef> LoadLocations(Stream s);
+        /// <summary>
+        /// Loads a collection of logic edits from a file.
+        /// </summary>
+        IEnumerable<RawLogicDef> LoadLogicEdits(Stream s);
+        /// <summary>
+        /// Loads a collection of macro edits from a file.
+        /// </summary>
+        Dictionary<string, string> LoadMacroEdits(Stream s);
+        /// <summary>
+        /// Loads a collection of logic substitutions from a file.
+        /// </summary>
+        IEnumerable<RawSubstDef> LoadLogicSubstitutions(Stream s);
+        /// <summary>
+        /// Loads a collection of item templates from a file.
+        /// </summary>
+        IEnumerable<ILogicItemTemplate> LoadItemTemplates(Stream s);
+        /// <summary>
+        /// Loads state data from a file.
+        /// </summary>
+        RawStateData LoadStateData(Stream s);
+    }
+}

--- a/RandomizerCore/Logic/LogicManagerBuilder.cs
+++ b/RandomizerCore/Logic/LogicManagerBuilder.cs
@@ -470,6 +470,93 @@ namespace RandomizerCore.Logic
             }
         }
 
+        public void DeserializeFile(JsonType type, ILogicFormat logicFormat, Stream s)
+
+        {
+            switch(type)
+            {
+                case JsonType.Terms:
+                    foreach ((string term, TermType termType) in logicFormat.LoadTerms(s))
+                    {
+                        GetOrAddTerm(term, termType);
+                    }
+                    break;
+
+                case JsonType.Waypoints:
+                    foreach (RawWaypointDef def in logicFormat.LoadWaypoints(s))
+                    {
+                        AddWaypoint(def);
+                    }
+                    break;
+
+                case JsonType.Transitions:
+                    foreach (RawLogicDef def in logicFormat.LoadTransitions(s))
+                    {
+                        AddTransition(def);
+                    }
+                    break;
+
+                case JsonType.Macros:
+                    LP.SetMacro(logicFormat.LoadMacros(s));
+                    break;
+
+                case JsonType.Items:
+                    foreach (object obj in logicFormat.LoadItems(s))
+                    {
+                        if (obj is LogicItem item)
+                        {
+                            AddItem(item);
+                        }
+                        else if (obj is ILogicItemTemplate templ)
+                        {
+                            AddTemplateItem(templ);
+                        }
+                        else
+                        {
+                            throw new FormatException($"Unexpected item of type {obj.GetType()} " +
+                                $"returned by logic format of type {logicFormat.GetType()}");
+                        }
+                    }
+                    break;
+
+                case JsonType.Locations:
+                    foreach (RawLogicDef def in logicFormat.LoadLocations(s))
+                    {
+                        AddLogicDef(def);
+                    }
+                    break;
+
+                case JsonType.LogicEdit:
+                    foreach (RawLogicDef def in logicFormat.LoadLogicEdits(s))
+                    {
+                        DoLogicEdit(def);
+                    }
+                    break;
+                case JsonType.MacroEdit:
+                    foreach (KeyValuePair<string, string> kvp in logicFormat.LoadMacroEdits(s))
+                    {
+                        DoMacroEdit(kvp);
+                    }
+                    break;
+
+                case JsonType.LogicSubst:
+                    foreach (RawSubstDef def in logicFormat.LoadLogicSubstitutions(s))
+                    {
+                        DoSubst(def);
+                    }
+                    break;
+                case JsonType.ItemTemplates:
+                    foreach (ILogicItemTemplate template in logicFormat.LoadItemTemplates(s))
+                    {
+                        AddTemplateItem(template);
+                    }
+                    break;
+                case JsonType.StateData:
+                    RawStateData rsd = logicFormat.LoadStateData(s);
+                    StateManager.AppendRawStateData(rsd);
+                    break;
+            }
+        }
         public Term GetTerm(string term)
         {
             return Terms.TermLookup[term];


### PR DESCRIPTION
I've made some deliberate design choices around how items are deserialized; I know we had discussed possibly returning JObject but it seems like the future we're envisioning here is that tight coupling to newtonsoft/json is undesirable and in the long run should eventually be removed, so I'd like to encourage format implementers to steer clear of that dependency and instead find ways to return safe item(template)s, e.g. encouraging the usage of ItemStrings once those are implemented.