### PR TITLE
Support .NET 8

### DIFF
--- a/RandomizerCore/Logic/ILogicFormat.cs
+++ b/RandomizerCore/Logic/ILogicFormat.cs
@@ -1,10 +1,5 @@
 ﻿using RandomizerCore.Logic.StateLogic;
 using RandomizerCore.LogicItems;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RandomizerCore.Logic
 {
@@ -16,6 +11,7 @@ namespace RandomizerCore.Logic
     {
         /// <summary>
         /// Loads a collection of terms from a file.
+        /// </summary>
         IEnumerable<(string, TermType)> LoadTerms(Stream s);
         /// <summary>
         /// Loads a collection of waypoints from a file.

--- a/RandomizerCore/RandomizerCore.csproj
+++ b/RandomizerCore/RandomizerCore.csproj
@@ -4,7 +4,7 @@
         <AssemblyTitle>RandomizerCore</AssemblyTitle>
         <AssemblyVersion>1.1.2.0</AssemblyVersion>
         <FileVersion>1.1.2.0</FileVersion>
-        <TargetFrameworks>netstandard2.1;net472;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net472;net6.0;net8.0</TargetFrameworks>
         <Deterministic>true</Deterministic>
         <LangVersion>latest</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/RandomizerCore/StringParsing/Exceptions.cs
+++ b/RandomizerCore/StringParsing/Exceptions.cs
@@ -6,9 +6,12 @@
         public TokenizingException() { }
         public TokenizingException(string message) : base(message) { }
         public TokenizingException(string message, Exception inner) : base(message, inner) { }
+
+#if !NET8_0_OR_GREATER
         protected TokenizingException(
           System.Runtime.Serialization.SerializationInfo info,
           System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+#endif
     }
 
     [Serializable]
@@ -17,8 +20,11 @@
         public ParsingException() { }
         public ParsingException(string message) : base(message) { }
         public ParsingException(string message, Exception inner) : base(message, inner) { }
+
+#if !NET8_0_OR_GREATER
         protected ParsingException(
           System.Runtime.Serialization.SerializationInfo info,
           System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+#endif
     }
 }

--- a/RandomizerCoreTests/RandomizerCoreTests.csproj
+++ b/RandomizerCoreTests/RandomizerCoreTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Add .net 8 targets to both projects. The StreamingContext overload of Exception constructor is deprecated in .NET 8 so removing it - probably it could also be removed from earlier versions too but I'm not sure under what scenario that usually gets used so I just left it.

I was also alerted to a malformed XML tag during a build and fixed it