### PR TITLE
Target .NET Standard 2.0

### DIFF
--- a/RandomizerCore/Collections/HashQueue.cs
+++ b/RandomizerCore/Collections/HashQueue.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+﻿﻿using System.Collections;
 using RandomizerCore.Extensions;
 
 namespace RandomizerCore.Logic
@@ -20,14 +20,15 @@ namespace RandomizerCore.Logic
         public HashQueue(int capacity)
         {
             queue = new Queue<T>(capacity);
+#if NETSTANDARD2_0
+            set = new HashSet<T>();
+#else
             set = new HashSet<T>(capacity);
+#endif
         }
 
         public HashQueue(IEnumerable<T> ts)
         {
-            queue = new Queue<T>();
-            set = new HashSet<T>();
-
             set = new HashSet<T>(ts);
             queue = new Queue<T>(set);
         }

--- a/RandomizerCore/RandomizerCore.csproj
+++ b/RandomizerCore/RandomizerCore.csproj
@@ -4,7 +4,7 @@
         <AssemblyTitle>RandomizerCore</AssemblyTitle>
         <VersionPrefix>2.0.2</VersionPrefix>
         <VersionSuffix></VersionSuffix>
-        <TargetFrameworks>netstandard2.1;net472;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0;net8.0</TargetFrameworks>
         <Deterministic>true</Deterministic>
         <LangVersion>latest</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/RandomizerCore/StringLogic/RPN.cs
+++ b/RandomizerCore/StringLogic/RPN.cs
@@ -154,7 +154,11 @@ namespace RandomizerCore.StringLogic
                             {
                                 for (int j = 0; j < andLeft.Count; j++)
                                 {
+#if NETSTANDARD2_0
+                                    HashSet<TermToken> c = new();
+#else
                                     HashSet<TermToken> c = new(andRight[i].Count + andLeft[j].Count);
+#endif
                                     c.UnionWith(andLeft[j]);
                                     c.UnionWith(andRight[i]);
                                     and.Add(c);

--- a/RandomizerCore/Updater/MainUpdater.cs
+++ b/RandomizerCore/Updater/MainUpdater.cs
@@ -73,7 +73,11 @@ namespace RandomizerCore.Logic
             individualEntries = new List<UpdateEntryBase>(2000);
             this.pm = pm;
             updates = new HashQueue<int>(lm.Terms.Count);
+#if NETSTANDARD2_0
+            addEntryHelper = new HashSet<int>();
+#else
             addEntryHelper = new HashSet<int>(lm.Terms.Count);
+#endif
             pmHooks = new();
             longTermRevertPoint = new(lm.Terms);
             shortTermRevertPoint = new(lm.Terms);


### PR DESCRIPTION
# Summary of changes

Adds a target for .NET standard 2.0 and introduces the first TFM-specific code in the project. This is necessary because at the moment all source generators and are essentially hard locked to this framework version, since msbuild runs in .NET Framework 4.7.2 in Visual Studio, but on .NET core on the command line.

Apparently on .NET Standard 2.0, HashSets cannot be initialized with a capacity. I opted to fixthis with preprocessor directives to keep the performance benefit where available, but am glad to change it to drop the arg on all TFMs if you prefer read/writeability over performance on the new TFMs

# Testing

Built and unit tested. Since .NET Standard is an API spec rather than a runtime we can't unit test it directly. And since we also target .NET Framework and .NET Core, any attempt to test on a real runtime will go through those. So to some extent we are flying blind, but since tests still pass on all the other TFMs it should be ok.