### PR TITLE
Modernize docs workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - directory: /
+    package-ecosystem: github-actions
+    schedule:
+      interval: daily

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,28 +6,26 @@ on:
 
 jobs:
   generate-docs:
-    runs-on: windows-2022
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: Checkout doc source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: docs_source
           path: docs
         
       # setup .NET
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         
       # Install DocFX
       - name: Setup DocFX
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install docfx
+        run: dotnet tool update -g docfx
       
       # Build and publish docs
       - name: DocFX build
@@ -36,7 +34,7 @@ jobs:
         continue-on-error: false
 
       - name: Publish
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_site


### PR DESCRIPTION
As I was preparing to write some docs, I found that the docs workflow is horrendously outdated in basically every way. This adds:
* updates all gh action dependencies
* updates runner to ubuntu-latest
* get docfx from the new recommended distribution channel (this is also more up to date than the one on chocolatey which I have plans to make use of)
* configure dependabot to keep it up to date for the future

this has to be done separately from the actual docs update because actions run off the main branch definition. Though there is a part of me wondering if it's worthwhile to just pull docs over to master and deal with the docs being next to the code, since this and every other future update has to be replicated to the docs branch as well.